### PR TITLE
All 24.04 specific PRs have been merged

### DIFF
--- a/overrides/ubuntu/24.04/overrides.yml
+++ b/overrides/ubuntu/24.04/overrides.yml
@@ -1,13 +1,6 @@
 ### Pending PRs only required for Ubuntu 24.04 ###
 # Remove when merged
-# https://github.com/rock-core/tools-service_discovery/pull/10
-- tools/service_discovery:
-  github: chhtz/tools-service_discovery
-  branch: fix/boost_timer
-# https://github.com/rock-core/tools-orocosrb/pull/159
-- tools/orocos.rb:
-  github: chhtz/tools-orocosrb
-  branch: master
+### No PRs at the moment
 ### End of 24.04 PRs ###
 
 


### PR DESCRIPTION
Currently, we could make the file a symbolic link to the 22.04 overrides as well (but I'll keep this, in case new 24.04 specific overrides are needed)